### PR TITLE
Fix errors in sensors

### DIFF
--- a/src/sa-bsn/target_system/components/component/src/g3t1_1/G3T1_1.cpp
+++ b/src/sa-bsn/target_system/components/component/src/g3t1_1/G3T1_1.cpp
@@ -94,7 +94,7 @@ double G3T1_1::collect() {
         ros::ServiceClient client = handle.serviceClient<std_srvs::SetBool>("spo2");
         std_srvs::SetBool srv;
         srv.request.data = true;
-            if (client.call(srv)) {
+        if (client.call(srv)) {
             res = srv.response.message;
             m_data = std::stof(res);
             ROS_INFO("new data collected: [%s]", std::to_string(m_data).c_str());

--- a/src/sa-bsn/target_system/components/component/src/g3t1_2/G3T1_2.cpp
+++ b/src/sa-bsn/target_system/components/component/src/g3t1_2/G3T1_2.cpp
@@ -90,7 +90,7 @@ double G3T1_2::collect() {
         ros::ServiceClient client = handle.serviceClient<std_srvs::SetBool>("bpm");
         std_srvs::SetBool srv;
         srv.request.data = true;
-            if (client.call(srv)) {
+        if (client.call(srv)) {
             res = srv.response.message;
             m_data = std::stof(res);
             ROS_INFO("new data collected: [%s]", std::to_string(m_data).c_str());
@@ -101,7 +101,7 @@ double G3T1_2::collect() {
         ros::ServiceClient client = handle.serviceClient<services::PatientData>("getPatientData");
         services::PatientData srv;
 
-        srv.request.vitalSign = "oxigenation";
+        srv.request.vitalSign = "heart_rate";
 
         if (client.call(srv)) {
             m_data = srv.response.data;

--- a/src/sa-bsn/target_system/components/component/src/g3t1_3/G3T1_3.cpp
+++ b/src/sa-bsn/target_system/components/component/src/g3t1_3/G3T1_3.cpp
@@ -92,7 +92,7 @@ double G3T1_3::collect() {
         ros::ServiceClient client = handle.serviceClient<std_srvs::SetBool>("temp");
         std_srvs::SetBool srv;
         srv.request.data = true;
-            if (client.call(srv)) {
+        if (client.call(srv)) {
             res = srv.response.message;
             m_data = std::stof(res);
             ROS_INFO("new data collected: [%s]", std::to_string(m_data).c_str());
@@ -103,7 +103,7 @@ double G3T1_3::collect() {
         ros::ServiceClient client = handle.serviceClient<services::PatientData>("getPatientData");
         services::PatientData srv;
 
-        srv.request.vitalSign = "oxigenation";
+        srv.request.vitalSign = "temperature";
 
         if (client.call(srv)) {
             m_data = srv.response.data;


### PR DESCRIPTION
Sensors were incorrectly configured.

The temperature and heart rate sensors were requesting the oxigenation instead of the respective data.