### PR TITLE
DevContainer fixes

### DIFF
--- a/.devcontainer/.tmux.conf
+++ b/.devcontainer/.tmux.conf
@@ -93,4 +93,4 @@ bind -n S-M-Up resize-pane -Z
 bind -n S-M-Down resize-pane -Z
 
 # see file .devcontainer/additional_bashrc for this command's source 
-set-hook -g session-closed "cleanupBSN"
+set-hook -g session-closed "/bin/bash -c cleanupBSN"

--- a/.devcontainer/additional_bashrc.sh
+++ b/.devcontainer/additional_bashrc.sh
@@ -18,3 +18,5 @@ function cleanupBSN() {
     kill $(cat /var/tmp/strategy_manager.pid && rm /var/tmp/strategy_manager.pid) & sleep 1s
     kill $(pgrep roscore)
 }
+
+export -f cleanupBSN

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,8 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/docker-existing-dockerfile
 {
-	"name": "Existing Dockerfile",
-	// Sets the run context to one level up instead of the .devcontainer folder.
+	"name": "SA-BSN",
 	"context": "..",
-	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	"dockerFile": "../Dockerfile.dev",
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
 	"postCreateCommand": "bash -c \"/workspaces/bsn/.devcontainer/postCreate.sh\""
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
 }

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,4 +1,3 @@
-python-rospy
-cd /workspaces/bsn &&\
-    rosdep install --from-paths src --ignore-src -r -y &&\
-    catkin_make
+cd /workspaces/bsn
+rosdep install --from-paths src --ignore-src -r -y
+catkin_make


### PR DESCRIPTION
Hi folks,
I have made a few small changes to the DevContainer.
Starting and stopping `./run_txmus now` works now as intended.

If you want I could also upgrade the README for the sake of using [DevContainer](https://containers.dev/).